### PR TITLE
Fixed the overlapping stories section

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -105,6 +105,7 @@ body {
   justify-content: space-between;
   align-items: center;
   position: relative;
+  z-index: -1;
   background: #fff;
   border: 1px solid #dfdfdf;
   border-radius: 8px;


### PR DESCRIPTION
Fixed the issue where the stories section was intersecting with the navbar. 
This PR is related to this [issue](https://github.com/priyanshumaitra/instagram-home-feed-clone/issues/28)

Current Behaviour:
![image](https://user-images.githubusercontent.com/89704304/196721072-948624c5-e904-42d9-af64-b6ec9f3004a0.png)
