### PR TITLE
fixed a bug in search bar

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -51,12 +51,14 @@ body {
   border: none;
   border-radius: 7px;
   color: rgba(0, 0, 0, 0.5);
-  /* text-align: left; */
-}
-.search::placeholder {
   font-size: 16px;
   padding-left: 15px;
+  /* text-align: left; */
 }
+/*.search::placeholder {
+  font-size: 16px;
+  padding-left: 15px;
+}*/
 .nav-items {
   height: 24px;
   position: relative;


### PR DESCRIPTION
Initially, the cursor wasn't given padding equal to "search" in the search bar which doesn't look good. This was looking like this.
![WhatsApp Image 2022-10-22 at 1 33 53 PM](https://user-images.githubusercontent.com/103296906/197328861-c4a2a3ed-5de6-43ef-b84c-e3102a59142d.jpeg)
But now I fixed that. It looks like this:
![image](https://user-images.githubusercontent.com/103296906/197328878-eb30447c-8335-4eaa-acca-4ba294ed66a2.png)
